### PR TITLE
Jest-ify tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/package-lock.json

--- a/extra/1-radio-stations.js
+++ b/extra/1-radio-stations.js
@@ -40,11 +40,11 @@ function getAvailableStations() {
     while (getAvailableStations.stations.length < stationCount) {
       let randomFrequency = Math.floor(Math.random() * (108 - 87 + 1) + 87);
       if (!getAvailableStations.stations.includes(randomFrequency)) {
-          getAvailableStations.stations.push(randomFrequency);
+        getAvailableStations.stations.push(randomFrequency);
       }
-    };
-    getAvailableStations.stations.sort(function(frequencyA, frequencyB) {
-        return frequencyA - frequencyB
+    }
+    getAvailableStations.stations.sort(function (frequencyA, frequencyB) {
+      return frequencyA - frequencyB;
     });
   }
 
@@ -57,28 +57,8 @@ function isRadioStation(frequency) {
 
 test("getAllFrequencies() returns all frequencies between 87 and 108", () => {
   expect(getAllFrequencies()).toEqual([
-    87,
-    88,
-    89,
-    90,
-    91,
-    92,
-    93,
-    94,
-    95,
-    96,
-    97,
-    98,
-    99,
-    100,
-    101,
-    102,
-    103,
-    104,
-    105,
-    106,
-    107,
-    108,
+    87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104,
+    105, 106, 107, 108,
   ]);
 });
 

--- a/extra/1-radio-stations.js
+++ b/extra/1-radio-stations.js
@@ -28,19 +28,23 @@
 
 /* ======= TESTS - DO NOT MODIFY ======= */
 
+const {expect, test} = require("@jest/globals");
+
 function getAvailableStations() {
   // Using `stations` as a property as defining it as a global variable wouldn't
   // always make it initialized before the function is called
   if (!getAvailableStations.stations) {
     const stationCount = 4;
-    getAvailableStations.stations = new Array(stationCount)
-      .fill(undefined)
-      .map(function () {
-        return Math.floor(Math.random() * (108 - 87 + 1) + 87);
-      })
-      .sort(function (frequencyA, frequencyB) {
-        return frequencyA - frequencyB;
-      });
+    getAvailableStations.stations = [];
+    while (getAvailableStations.stations.length < stationCount) {
+      let randomFrequency = Math.floor(Math.random() * (108 - 87 + 1) + 87);
+      if (!getAvailableStations.stations.includes(randomFrequency)) {
+          getAvailableStations.stations.push(randomFrequency);
+      }
+    };
+    getAvailableStations.stations.sort(function(frequencyA, frequencyB) {
+        return frequencyA - frequencyB
+    });
   }
 
   return getAvailableStations.stations;
@@ -50,22 +54,8 @@ function isRadioStation(frequency) {
   return getAvailableStations().includes(frequency);
 }
 
-const assert = require("assert");
-
-function test(testName, fn) {
-  try {
-    fn();
-    console.log(`\n✅ ${testName}: PASS`);
-  } catch (error) {
-    console.log(
-      `\n❌ ${testName}: FAIL (see details below)\n\n${error.message}`
-    );
-  }
-}
-
-test("getAllFrequencies() returns all frequencies between 87 and 108", function () {
-  const frequencies = getAllFrequencies();
-  assert.deepStrictEqual(frequencies, [
+test("getAllFrequencies() returns all frequencies between 87 and 108", () => {
+  expect(getAllFrequencies()).toEqual([
     87,
     88,
     89,
@@ -92,6 +82,5 @@ test("getAllFrequencies() returns all frequencies between 87 and 108", function 
 });
 
 test("getStations() returns all the available stations", () => {
-  const stations = getStations();
-  assert.deepStrictEqual(stations, getAvailableStations());
+  expect(getStations()).toEqual(getAvailableStations());
 });

--- a/extra/1-radio-stations.js
+++ b/extra/1-radio-stations.js
@@ -28,8 +28,6 @@
 
 /* ======= TESTS - DO NOT MODIFY ======= */
 
-const {expect, test} = require("@jest/globals");
-
 function getAvailableStations() {
   // Using `stations` as a property as defining it as a global variable wouldn't
   // always make it initialized before the function is called

--- a/extra/1-radio-stations.js
+++ b/extra/1-radio-stations.js
@@ -26,7 +26,10 @@
  */
 // `getStations` goes here
 
-/* ======= TESTS - DO NOT MODIFY ======= */
+/*
+ * ======= TESTS - DO NOT MODIFY =======
+ * Note: You are not expected to understand everything below this comment!
+ */
 
 function getAvailableStations() {
   // Using `stations` as a property as defining it as a global variable wouldn't

--- a/mandatory/1-fix-functions.js
+++ b/mandatory/1-fix-functions.js
@@ -30,18 +30,6 @@ function greaterThan10(num) {
   }
 }
 
-function sortArray(letters) {
-  let sortedLetters = letters;
-
-  return sortedLetters;
-}
-
-function first5(numbers) {
-  let sliced;
-
-  return sliced;
-}
-
 function get3rdIndex(arr) {
   let index = 3;
   let element;
@@ -51,80 +39,45 @@ function get3rdIndex(arr) {
 
 /* ======= TESTS - DO NOT MODIFY ===== */
 
-const util = require("util");
+const {expect, test} = require("@jest/globals");
 
-function test(test_name, actual, expected) {
-  let status;
+test("mood function works for true", () => {
+    expect(mood(true)).toEqual("I am happy");
+});
 
-  let isEqual;
-  if (Array.isArray(expected)) {
-    isEqual = arraysEqual(actual, expected);
-  } else {
-    isEqual = actual === expected;
-  }
+test("mood function works for false", () => {
+    expect(mood(false)).toEqual("I am not happy");
+});
 
-  if (isEqual) {
-    status = "PASSED";
-  } else {
-    status = `FAILED: expected: ${util.inspect(
-      expected
-    )} but your function returned: ${util.inspect(actual)}`;
-  }
+test("greaterThanTen function works for value greater than 10", () => {
+    expect(greaterThan10(11)).toEqual("num is greater than 10");
+});
 
-  console.log(`${test_name}: ${status}`);
-}
+test("greaterThanTen function works for value less than 10", () => {
+    expect(greaterThan10(9)).toEqual("num is not big enough");
+});
 
-function arraysEqual(a, b) {
-  if (a === b) return true;
-  if (a == null || b == null) return false;
-  if (a.length != b.length) return false;
+test("greaterThanTen function works for value equal to 10", () => {
+    expect(greaterThan10(10)).toEqual("num is not big enough");
+});
 
-  for (let i = 0; i < a.length; ++i) {
-    if (a[i] !== b[i]) return false;
-  }
+test("get3rdIndex function works with strings", () => {
+    const strings = ["fruit", "banana", "apple", "strawberry", "raspberry"];
+    const copyOfOriginal = strings.slice();
+    expect(get3rdIndex(strings)).toEqual("strawberry");
+    // Make sure get3rdIndex didn't change its input array.
+    expect(strings).toEqual(copyOfOriginal);
+});
 
-  return true;
-}
+test("get3rdIndex function works with numbers", () => {
+    const numbers = [11, 37, 62, 18, 19, 3, 30];
+    const copyOfOriginal = numbers.slice();
+    expect(get3rdIndex(numbers)).toEqual(18);
+    // Make sure get3rdIndex didn't change its input array.
+    expect(numbers).toEqual(copyOfOriginal);
+});
 
-test("mood function works for true", mood(true), "I am happy");
-test("mood function works for false", mood(false), "I am not happy");
-test(
-  "greaterThanTen function works for 11",
-  greaterThan10(11),
-  "num is greater than 10"
-);
-test(
-  "greaterThanTen function works for 10",
-  greaterThan10(10),
-  "num is not big enough"
-);
-test(
-  "greaterThanTen function works for 9",
-  greaterThan10(9),
-  "num is not big enough"
-);
-test("sortArray function works", sortArray(["a", "n", "c", "e", "z", "f"]), [
-  "a",
-  "c",
-  "e",
-  "f",
-  "n",
-  "z",
-]);
-
-let numbers = [1, 2, 3, 4, 5, 6, 7, 8];
-test("first5 function works", first5(numbers), [1, 2, 3, 4, 5]);
-if (!arraysEqual(numbers, [1, 2, 3, 4, 5, 6, 7, 8])) {
-  console.log("PROBLEM: first5 changed its input array - it shouldn't!");
-}
-
-test(
-  "get3rdIndex function works - case 1",
-  get3rdIndex(["fruit", "banana", "apple", "strawberry", "raspberry"]),
-  "strawberry"
-);
-test(
-  "get3rdIndex function works - case 2",
-  get3rdIndex([11, 37, 62, 18, 19, 3, 30]),
-  18
-);
+test("get3rdIndex returns undefined if not enough elements", () => {
+    const numbers = [5, 10];
+    expect(get3rdIndex(numbers)).toBeUndefined();
+})

--- a/mandatory/1-fix-functions.js
+++ b/mandatory/1-fix-functions.js
@@ -51,6 +51,10 @@ test("greaterThanTen function works for value greater than 10", () => {
   expect(greaterThan10(11)).toEqual("num is greater than 10");
 });
 
+test("greaterThanTen function works for value much greater than 10", () => {
+  expect(greaterThan10(96)).toEqual("num is greater than 10");
+});
+
 test("greaterThanTen function works for value less than 10", () => {
   expect(greaterThan10(9)).toEqual("num is not big enough");
 });

--- a/mandatory/1-fix-functions.js
+++ b/mandatory/1-fix-functions.js
@@ -39,8 +39,6 @@ function get3rdIndex(arr) {
 
 /* ======= TESTS - DO NOT MODIFY ===== */
 
-const {expect, test} = require("@jest/globals");
-
 test("mood function works for true", () => {
     expect(mood(true)).toEqual("I am happy");
 });

--- a/mandatory/1-fix-functions.js
+++ b/mandatory/1-fix-functions.js
@@ -40,42 +40,42 @@ function get3rdIndex(arr) {
 /* ======= TESTS - DO NOT MODIFY ===== */
 
 test("mood function works for true", () => {
-    expect(mood(true)).toEqual("I am happy");
+  expect(mood(true)).toEqual("I am happy");
 });
 
 test("mood function works for false", () => {
-    expect(mood(false)).toEqual("I am not happy");
+  expect(mood(false)).toEqual("I am not happy");
 });
 
 test("greaterThanTen function works for value greater than 10", () => {
-    expect(greaterThan10(11)).toEqual("num is greater than 10");
+  expect(greaterThan10(11)).toEqual("num is greater than 10");
 });
 
 test("greaterThanTen function works for value less than 10", () => {
-    expect(greaterThan10(9)).toEqual("num is not big enough");
+  expect(greaterThan10(9)).toEqual("num is not big enough");
 });
 
 test("greaterThanTen function works for value equal to 10", () => {
-    expect(greaterThan10(10)).toEqual("num is not big enough");
+  expect(greaterThan10(10)).toEqual("num is not big enough");
 });
 
 test("get3rdIndex function works with strings", () => {
-    const strings = ["fruit", "banana", "apple", "strawberry", "raspberry"];
-    const copyOfOriginal = strings.slice();
-    expect(get3rdIndex(strings)).toEqual("strawberry");
-    // Make sure get3rdIndex didn't change its input array.
-    expect(strings).toEqual(copyOfOriginal);
+  const strings = ["fruit", "banana", "apple", "strawberry", "raspberry"];
+  const copyOfOriginal = strings.slice();
+  expect(get3rdIndex(strings)).toEqual("strawberry");
+  // Make sure get3rdIndex didn't change its input array.
+  expect(strings).toEqual(copyOfOriginal);
 });
 
 test("get3rdIndex function works with numbers", () => {
-    const numbers = [11, 37, 62, 18, 19, 3, 30];
-    const copyOfOriginal = numbers.slice();
-    expect(get3rdIndex(numbers)).toEqual(18);
-    // Make sure get3rdIndex didn't change its input array.
-    expect(numbers).toEqual(copyOfOriginal);
+  const numbers = [11, 37, 62, 18, 19, 3, 30];
+  const copyOfOriginal = numbers.slice();
+  expect(get3rdIndex(numbers)).toEqual(18);
+  // Make sure get3rdIndex didn't change its input array.
+  expect(numbers).toEqual(copyOfOriginal);
 });
 
 test("get3rdIndex returns undefined if not enough elements", () => {
-    const numbers = [5, 10];
-    expect(get3rdIndex(numbers)).toBeUndefined();
-})
+  const numbers = [5, 10];
+  expect(get3rdIndex(numbers)).toBeUndefined();
+});

--- a/mandatory/2-function-creation.js
+++ b/mandatory/2-function-creation.js
@@ -1,11 +1,11 @@
 /*
 Write a function that:
-- takes an array of strings as input
-- removes any spaces in the beginning or end of the strings
-- removes any forward slashes (/) in the strings
+- takes a string as input
+- removes any spaces in the beginning or end of the string
+- removes any forward slashes (/) in the string
 - makes the string all lowercase
 */
-function tidyUpString(strArr) {}
+function tidyUpString(str) {}
 
 /*
 Complete the function to check if the variable `num` satisfies the following requirements:
@@ -17,93 +17,66 @@ Tip: use logical operators
 
 function validate(num) {}
 
-/* 
-Write a function that returns a copy of the given array arr, but with the element at the given index, index removed.
-The function must NOT change the original array, arr.
-*/
-
-function remove(arr, index) {
-  return; // complete this statement
-}
-
 /*
 Write a function that:
-- takes an array of numbers as input
-- returns an array of strings formatted as percentages (e.g. 10 => "10%")
-- the numbers must be rounded to 2 decimal places
+- takes a number as input
+- return a string formatted as percentages (e.g. 10 => "10%")
+- the number must be rounded to 2 decimal places
 - numbers greater 100 must be replaced with 100
 */
 
-function formatPercentage(arr) {}
+function formatPercentage(num) {}
 
 /* ======= TESTS - DO NOT MODIFY ===== */
 
-const util = require("util");
+const {expect, test} = require("@jest/globals");
 
-function test(test_name, actual, expected) {
-  let status;
+test.each([
+  ["/Daniel", "daniel"],
+  [" Sanyia/", "sanyia"],
+  ["AnTHonY", "anthony"],
+  ["irina", "irina"],
+  [" Gordon", "gordon"],
+  ["ashleigh  ", "ashleigh"],
+  ["  Alastair  ", "alastair"],
+  [" anne marie  ", "anne marie"],
+])("tidyUpString function works for %s", (input, expected) => {
+    expect(tidyUpString(input)).toEqual(expected);
+});
 
-  let isEqual;
-  if (Array.isArray(expected)) {
-    isEqual = arraysEqual(actual, expected);
-  } else {
-    isEqual = actual === expected;
-  }
+test("validate function accepts valid even number", () => {
+    expect(validate(10)).toEqual(true);
+});
 
-  if (isEqual) {
-    status = "PASSED";
-  } else {
-    status = `FAILED: expected: ${util.inspect(
-      expected
-    )} but your function returned: ${util.inspect(actual)}`;
-  }
+test("validate function accepts other valid even number", () => {
+    expect(validate(18)).toEqual(true);
+});
 
-  console.log(`${test_name}: ${status}`);
-}
+test("validate function accepts exactly 100", () => {
+    expect(validate(100)).toEqual(true);
+});
 
-function arraysEqual(a, b) {
-  if (a === b) return true;
-  if (a == null || b == null) return false;
-  if (a.length != b.length) return false;
+test("validate function works rejects odd number", () => {
+    expect(validate(17)).toEqual(false);
+});
 
-  for (let i = 0; i < a.length; ++i) {
-    if (a[i] !== b[i]) return false;
-  }
+test("validate function works rejects string", () => {
+    expect(validate("Ten")).toEqual(false);
+});
 
-  return true;
-}
+test("validate function works rejects stringified number", () => {
+    expect(validate("10")).toEqual(false);
+});
 
-test(
-  "tidyUpString function works - case 1",
-  tidyUpString(["/Daniel ", "irina ", " Gordon", "ashleigh "]),
-  ["daniel", "irina", "gordon", "ashleigh"]
-);
-test(
-  "tidyUpString function works - case 2",
-  tidyUpString([" /Sanyia ", " Michael ", "AnTHonY ", "   Tim   "]),
-  ["sanyia", "michael", "anthony", "tim"]
-);
+test("validate function works rejects too large number", () => {
+    expect(validate(108)).toEqual(false);
+});
 
-test("validate function works - case 1", validate(10), true);
-test("validate function works - case 2", validate(18), true);
-test("validate function works - case 3", validate(17), false);
-test("validate function works - case 4", validate("Ten"), false);
-test("validate function works - case 5", validate(108), false);
-
-test("remove function works - case 1", remove([10, 293, 292, 176, 29], 3), [
-  10,
-  293,
-  292,
-  29,
-]);
-test(
-  "remove function works - case 2",
-  remove(["a", "b", "c", "d", "e", "f", "g"], 6),
-  ["a", "b", "c", "d", "e", "f"]
-);
-
-test(
-  "formatPercentage function works - case 1",
-  formatPercentage([23, 18.103, 187.2, 0.372]),
-  ["23%", "18.1%", "100%", "0.37%"]
-);
+test.each([
+    [23, "23%"],
+    [18.103, "18.1%"],
+    [187.2, "100%"],
+    [0.372, "0.37%"],
+])("formatPercentage function works for %s", (input, expected) => {
+    expect(formatPercentage(input)).toEqual(expected);
+});

--- a/mandatory/2-function-creation.js
+++ b/mandatory/2-function-creation.js
@@ -62,7 +62,7 @@ test("validate function rejects string", () => {
   expect(validate("Ten")).toEqual(false);
 });
 
-test("validate function works rejects stringified number", () => {
+test("validate function rejects stringified number", () => {
   expect(validate("10")).toEqual(false);
 });
 

--- a/mandatory/2-function-creation.js
+++ b/mandatory/2-function-creation.js
@@ -58,7 +58,7 @@ test("validate function rejects odd number", () => {
   expect(validate(17)).toEqual(false);
 });
 
-test("validate function works rejects string", () => {
+test("validate function rejects string", () => {
   expect(validate("Ten")).toEqual(false);
 });
 

--- a/mandatory/2-function-creation.js
+++ b/mandatory/2-function-creation.js
@@ -54,7 +54,7 @@ test("validate function accepts exactly 100", () => {
   expect(validate(100)).toEqual(true);
 });
 
-test("validate function works rejects odd number", () => {
+test("validate function rejects odd number", () => {
   expect(validate(17)).toEqual(false);
 });
 

--- a/mandatory/2-function-creation.js
+++ b/mandatory/2-function-creation.js
@@ -1,13 +1,4 @@
 /*
-Write a function that:
-- takes a string as input
-- removes any spaces in the beginning or end of the string
-- removes any forward slashes (/) in the string
-- makes the string all lowercase
-*/
-function tidyUpString(str) {}
-
-/*
 Complete the function to check if the variable `num` satisfies the following requirements:
 - is a number
 - is even
@@ -27,20 +18,16 @@ Write a function that:
 
 function formatPercentage(num) {}
 
-/* ======= TESTS - DO NOT MODIFY ===== */
+/*
+Write a function that:
+- takes an array of strings as input
+- removes any spaces in the beginning or end of each string
+- removes any forward slashes (/) in each string
+- makes all strings all lowercase
+*/
+function tidyUpStrings(arrayOfStrings) {}
 
-test.each([
-  ["/Daniel", "daniel"],
-  [" Sanyia/", "sanyia"],
-  ["AnTHonY", "anthony"],
-  ["irina", "irina"],
-  [" Gordon", "gordon"],
-  ["ashleigh  ", "ashleigh"],
-  ["  Alastair  ", "alastair"],
-  [" anne marie  ", "anne marie"],
-])("tidyUpString function works for %s", (input, expected) => {
-  expect(tidyUpString(input)).toEqual(expected);
-});
+/* ======= TESTS - DO NOT MODIFY ===== */
 
 test("validate function accepts valid even number", () => {
   expect(validate(10)).toEqual(true);
@@ -77,4 +64,28 @@ test.each([
   [0.372, "0.37%"],
 ])("formatPercentage function works for %s", (input, expected) => {
   expect(formatPercentage(input)).toEqual(expected);
+});
+
+test("tidyUpString function works", () => {
+  expect(
+    tidyUpStrings([
+      "/Daniel",
+      " /Sanyia",
+      "AnTHonY",
+      "irina",
+      " Gordon",
+      "ashleigh   ",
+      "   Alastair  ",
+      " anne marie  ",
+    ])  
+  ).toEqual([
+    "daniel",
+    "sanyia",
+    "anthony",
+    "irina",
+    "gordon",
+    "ashleigh",
+    "alastair",
+    "anne marie",
+  ]); 
 });

--- a/mandatory/2-function-creation.js
+++ b/mandatory/2-function-creation.js
@@ -66,7 +66,7 @@ test("validate function rejects stringified number", () => {
   expect(validate("10")).toEqual(false);
 });
 
-test("validate function works rejects too large number", () => {
+test("validate function rejects too large number", () => {
   expect(validate(108)).toEqual(false);
 });
 

--- a/mandatory/2-function-creation.js
+++ b/mandatory/2-function-creation.js
@@ -39,42 +39,42 @@ test.each([
   ["  Alastair  ", "alastair"],
   [" anne marie  ", "anne marie"],
 ])("tidyUpString function works for %s", (input, expected) => {
-    expect(tidyUpString(input)).toEqual(expected);
+  expect(tidyUpString(input)).toEqual(expected);
 });
 
 test("validate function accepts valid even number", () => {
-    expect(validate(10)).toEqual(true);
+  expect(validate(10)).toEqual(true);
 });
 
 test("validate function accepts other valid even number", () => {
-    expect(validate(18)).toEqual(true);
+  expect(validate(18)).toEqual(true);
 });
 
 test("validate function accepts exactly 100", () => {
-    expect(validate(100)).toEqual(true);
+  expect(validate(100)).toEqual(true);
 });
 
 test("validate function works rejects odd number", () => {
-    expect(validate(17)).toEqual(false);
+  expect(validate(17)).toEqual(false);
 });
 
 test("validate function works rejects string", () => {
-    expect(validate("Ten")).toEqual(false);
+  expect(validate("Ten")).toEqual(false);
 });
 
 test("validate function works rejects stringified number", () => {
-    expect(validate("10")).toEqual(false);
+  expect(validate("10")).toEqual(false);
 });
 
 test("validate function works rejects too large number", () => {
-    expect(validate(108)).toEqual(false);
+  expect(validate(108)).toEqual(false);
 });
 
 test.each([
-    [23, "23%"],
-    [18.103, "18.1%"],
-    [187.2, "100%"],
-    [0.372, "0.37%"],
+  [23, "23%"],
+  [18.103, "18.1%"],
+  [187.2, "100%"],
+  [0.372, "0.37%"],
 ])("formatPercentage function works for %s", (input, expected) => {
-    expect(formatPercentage(input)).toEqual(expected);
+  expect(formatPercentage(input)).toEqual(expected);
 });

--- a/mandatory/2-function-creation.js
+++ b/mandatory/2-function-creation.js
@@ -29,8 +29,6 @@ function formatPercentage(num) {}
 
 /* ======= TESTS - DO NOT MODIFY ===== */
 
-const {expect, test} = require("@jest/globals");
-
 test.each([
   ["/Daniel", "daniel"],
   [" Sanyia/", "sanyia"],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "javascript-core-1-coursework-week2",
+  "version": "1.0.0",
+  "description": "Exercises for JS1 Week 2",
+  "scripts": {
+    "test": "jest --testRegex='mandatory[/\\\\].*\\.js$' --testPathIgnorePatterns=playing-computer",
+    "extra-tests": "jest --testRegex='extra[/\\\\].*\\.js$'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CodeYourFuture/JavaScript-Core-1-Coursework-Week2.git"
+  },
+  "bugs": {
+    "url": "https://github.com/CodeYourFuture/JavaScript-Core-1-Coursework-Week2/issues"
+  },
+  "homepage": "https://github.com/CodeYourFuture/JavaScript-Core-1-Coursework-Week2#readme",
+  "devDependencies": {
+    "jest": "^26.6.3"
+  }
+}


### PR DESCRIPTION
There are also several modifications to tests here:
* mandatory/1-fix-functions.js no longer has `sortArray` or `first5`
  exercises - we moved array methods to week 3, so the tests should move
  there too.
* mandatory/2-function-creation.js has some array-based tests changed to
  instead test the same function creation but for single values. We
  moved teaching `map` to week 3, I'll re-add the array versions of
  these tests to week 3.
* extra/1-radio-stations.js changes how we populate the expected
  stations list, because the tests were previously failing if duplicate
  stations were generated by the random generator.